### PR TITLE
[AT-26] create delete image button

### DIFF
--- a/components/EditActivity.jsx
+++ b/components/EditActivity.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { axiosInstance } from "../utils/axiosInstance";
 import { mutate } from "swr";
+import { RxCross2 } from "react-icons/rx";
 
 export function EditActivity(props) {
   const {
@@ -12,6 +13,7 @@ export function EditActivity(props) {
     reset,
   } = useForm();
 
+  const [showImagePreview, setShowImagePreview] = useState(true);
   const [imageFile, setImageFile] = useState(null);
   const [previewImage, setPreviewImage] = useState(null);
   const [error, setError] = useState(null);
@@ -38,7 +40,7 @@ export function EditActivity(props) {
     } else if (props.item.imageUrl) {
       newActivity = {
         ...newActivity,
-        imageUrl: props.item.imageUrl,
+        imageUrl: null,
       };
     }
 
@@ -81,22 +83,41 @@ export function EditActivity(props) {
     reader.readAsDataURL(selectedFile);
     reader.onloadend = () => {
       setImageFile(reader.result);
-      setPreviewImage(reader.result); // Set the preview image to the selected image
+      setPreviewImage(reader.result);
     };
   };
+
+  const handleDeleteImage = (event) => {
+    event.preventDefault();
+    setPreviewImage(null);
+    setImageFile(null);
+    setShowImagePreview(false);
+  };
+
   return (
     <div className="form-container">
       <form onSubmit={handleSubmit(onSubmit)}>
         <h3>Edit Activity</h3>
         <div className="image-container">
           <div>
-            {(previewImage || props.item.imageUrl) && (
-              <img
-                className="image-preview"
-                src={previewImage || props.item.imageUrl}
-                alt="Selected file"
-                style={{ maxWidth: "100%", maxHeight: "100%" }}
-              />
+            {showImagePreview && (previewImage || props.item.imageUrl) && (
+              <div className="relative">
+                <img
+                  className="image-preview"
+                  src={previewImage || props.item.imageUrl}
+                  alt="Selected file"
+                  style={{ maxWidth: "100%", maxHeight: "100%" }}
+                />
+                <div className="w-[35px] h-[35px] top-1 right-1 absolute">
+                  <button
+                    onClick={handleDeleteImage}
+                    type="button"
+                    className="flex items-center justify-center rounded-full w-full h-full bg-red-500 text-white"
+                  >
+                    <RxCross2 className="w-5 h-5" />
+                  </button>
+                </div>
+              </div>
             )}
           </div>
           <label htmlFor="image">Choose an image:</label>

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-datepicker": "^4.11.0",
         "react-dom": "18.2.0",
         "react-hook-form": "^7.43.9",
+        "react-icons": "^4.8.0",
         "react-modal": "^3.16.1",
         "sass": "^1.62.1",
         "swr": "^2.1.5",
@@ -4051,6 +4052,14 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
+      "integrity": "sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-datepicker": "^4.11.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.43.9",
+    "react-icons": "^4.8.0",
     "react-modal": "^3.16.1",
     "sass": "^1.62.1",
     "swr": "^2.1.5",


### PR DESCRIPTION
# Ticket อะไร

at-26

# Ticket นี้ทำอะไรมาบ้าง

- เพิ่มปุ่ม delete image ไว้กด delete post ที่มีรูป โพสต์ไหนไม่มีรูปจะไม่มีปุ่มขึ้นมา

# Screenshot ถ้าทำ UI ฝากแปะรูปภาพ UI ที่ทำไว้ด้วย

ตรงนี้เอารูปลากมาวางได้
<img width="598" alt="ภาพถ่ายหน้าจอ 2566-05-18 เวลา 21 55 55" src="https://github.com/pkpndLiZ/actitvity-tracking-web/assets/125846537/33235dc8-88a1-4749-bf5b-870d073fc3e8">
